### PR TITLE
GHC 8.4 compatibility fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ addons:
     packages:
       - libgmp-dev
 
+matrix:
+  include:
+    - env: GHCVER=8.4.2  STACK_YAML=stack-8.4.2.yaml  CACHE_NAME=ghc-8.4.2
+    - env: GHCVER=8.2.2  STACK_YAML=stack-8.2.2.yaml  CACHE_NAME=ghc-8.2.2
+    - env: GHCVER=8.0.2  STACK_YAML=stack-8.0.2.yaml  CACHE_NAME=ghc-8.0.2
+    - env: GHCVER=7.10.3 STACK_YAML=stack-7.10.3.yaml CACHE_NAME=ghc-7.10.3
+
 before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin

--- a/src/Data/Text/ICU/Replace.hs
+++ b/src/Data/Text/ICU/Replace.hs
@@ -40,7 +40,7 @@ module Data.Text.ICU.Replace
 import           Control.Applicative
 import           Data.Attoparsec.Text
 import           Data.Foldable
-#if __GLASGOW_HASKELL__ < 804
+#if __GLASGOW_HASKELL__ >= 804
 import           Data.Semigroup (Semigroup)
 #endif
 import           Data.Monoid
@@ -63,7 +63,7 @@ import           Prelude                hiding (span)
 -- construct them.
 newtype Replace = Replace { unReplace :: Match -> TB.Builder } deriving
                   ( Monoid
-#if __GLASGOW_HASKELL__ < 804
+#if __GLASGOW_HASKELL__ >= 804
                   , Semigroup
 #endif
                   )

--- a/stack-7.10.3.yaml
+++ b/stack-7.10.3.yaml
@@ -1,0 +1,3 @@
+resolver: lts-6.35
+packages:
+- .

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -1,0 +1,3 @@
+resolver: lts-9.21
+packages:
+- .

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,0 +1,3 @@
+resolver: lts-11.10
+packages:
+- .

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2018-05-25
+packages:
+- .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,1 @@
-#resolver: nightly-2018-04-01
-resolver: lts-11.3
-packages:
-- .
+stack-8.2.2.yaml


### PR DESCRIPTION
- Fixed condition in CPP to derive Semigroup in 8.4 and above, not below 8.4
- Added build matrix with several GHC versions