### PR TITLE
Loosen text version constraint

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ maintainer: erochest@gmail.com
 license: Apache-2.0
 git: git://github.com/erochest/text-regex-replace.git
 dependencies:
-- text >=1.2 && <1.3
+- text >=1.2
 - text-icu >=0.7 && <0.9
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,1 @@
-resolver: lts-18.25
-packages:
-- .
-extra-deps:
-- directory-1.3.6.0
-- time-1.9.3
+stack-8.10.7.yaml

--- a/text-regex-replace.cabal
+++ b/text-regex-replace.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -33,7 +33,7 @@ library
   build-depends:
       attoparsec >=0.12 && <0.15
     , base >=4.7 && <5
-    , text ==1.2.*
+    , text >=1.2
     , text-icu >=0.7 && <0.9
   default-language: Haskell2010
 
@@ -51,7 +51,7 @@ test-suite text-regex-replace-specs
     , base
     , hspec
     , smallcheck
-    , text ==1.2.*
+    , text >=1.2
     , text-icu >=0.7 && <0.9
     , text-regex-replace
   default-language: Haskell2010


### PR DESCRIPTION
This PR allows this library to be used with `text` versions `>= 2.0`. According to the manual testing I've done it seems to work just fine. It also fixes the symlink of `stack.yaml`, which seemed to contain the contents of the file it was referring to, rather than the file itself.